### PR TITLE
BACKEND-11: Add debug route

### DIFF
--- a/.envtemplate
+++ b/.envtemplate
@@ -1,5 +1,4 @@
-NODE_ENV=[insert here, either 'local', 'development', or 'production']
-LOCAL_URI=[insert here]
+NODE_ENV=[insert here, either 'dev', or 'prod']
 DEV_URI=[insert here]
 PROD_URI=[insert here]
 CLIENT_ID=[insert here]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Backend for announcements.
 
 ## Getting Started
 
-1. Duplicate the `.envtemplate` file and rename it to `.env`. Set `NODE_ENV` to either `local`, `development`, or `production`. Then, set `LOCAL_URI`, `DEV_URI` and `PROD_URI` to the MongoDB drvie connection URIs for all 3 environments.
+1. Duplicate the `.envtemplate` file and rename it to `.env`. Set `NODE_ENV` to `dev`, then set `DEV_URI` to `mongodb://localhost:27017/announcements-dev`.
 
-- For AppDev members, the local `.env` file is pinned in the `#announcements-dev` channel.
+- For AppDev members, the development `.env` file is pinned in the `#announcements-dev` channel.
 - Note that in order to run the database locally, you will need to have MongoDB installed.
 
 2. Run `yarn` to install dependencies.

--- a/src/announcements/examples.ts
+++ b/src/announcements/examples.ts
@@ -8,6 +8,7 @@ export const exampleAnnouncement = {
   endDate: "2024-08-16T03:00:00Z",
   imageUrl:
     "https://appdev-upload.nyc3.digitaloceanspaces.com/announcements/pc6k6o8z.png",
+  isDebug: false,
   link: "https://www.instagram.com/p/C4ft4SyOaUj/",
   startDate: "2024-08-15T03:00:00Z",
   title: "Demo Day",

--- a/src/announcements/models.ts
+++ b/src/announcements/models.ts
@@ -38,6 +38,9 @@ export class Announcement {
   @prop()
   public imageUrl!: string;
 
+  @prop({ default: false })
+  public isDebug!: boolean;
+
   @prop()
   public link!: string;
 

--- a/src/announcements/routes.ts
+++ b/src/announcements/routes.ts
@@ -11,6 +11,7 @@ import {
   Path,
   Post,
   Put,
+  Query,
   Route,
   SuccessResponse,
 } from "tsoa";
@@ -35,8 +36,10 @@ export class AnnouncementController extends Controller {
    */
   @Get()
   @Example(exampleAnnouncements)
-  public async getAllUsers(): Promise<Announcement[]> {
-    return this.announcementService.getAnnouncements();
+  public async getAllAnnouncements(
+    @Query() debug: boolean
+  ): Promise<Announcement[]> {
+    return this.announcementService.getAnnouncements(debug);
   }
 
   /**
@@ -99,8 +102,9 @@ export class AnnouncementController extends Controller {
    */
   @Get("{slug}")
   public async activeAnnouncements(
-    @Path() slug: string
+    @Path() slug: string,
+    @Query() debug: boolean
   ): Promise<Announcement[]> {
-    return this.appService.getActiveAnnouncements(slug);
+    return this.appService.getActiveAnnouncements(slug, debug);
   }
 }

--- a/src/announcements/services.ts
+++ b/src/announcements/services.ts
@@ -8,10 +8,14 @@ export class AnnouncementService {
   /**
    * Fetch all announcements from the database.
    *
+   * @param isDebug Whether to fetch announcements that are for debugging purposes.
    * @returns A promise resolving to all announcements or error.
    */
-  public getAnnouncements = async () => {
-    return await AnnouncementModel.find();
+  public getAnnouncements = async (isDebug: boolean) => {
+    if (isDebug) {
+      return await AnnouncementModel.find({ isDebug: true });
+    }
+    return await AnnouncementModel.find({ isDebug: false });
   };
 
   /**

--- a/src/announcements/types.ts
+++ b/src/announcements/types.ts
@@ -3,6 +3,7 @@ export type AnnouncementCreationParams = {
   body: string;
   endDate: Date;
   imageUrl: string;
+  isDebug: boolean;
   link: string;
   startDate: Date;
   title: string;
@@ -13,6 +14,7 @@ export type AnnouncementUpdateParams = {
   body?: string;
   endDate?: Date;
   imageUrl?: string;
+  isDebug?: boolean;
   link?: string;
   startDate?: Date;
   title?: string;

--- a/src/apps/services.ts
+++ b/src/apps/services.ts
@@ -70,13 +70,23 @@ export class AppService {
    * Fetch all active announcements from the database for a given app.
    *
    * @param slug The slug nickname of the app.
+   * @param isDebug Whether to fetch announcements that are for debugging purposes.
    * @returns A promise resolving to the active announcements or error.
    */
-  public getActiveAnnouncements = async (slug: string) => {
+  public getActiveAnnouncements = async (slug: string, isDebug: boolean) => {
+    if (isDebug) {
+      return await AnnouncementModel.find({
+        apps: slug,
+        startDate: { $lte: new Date() },
+        endDate: { $gte: new Date() },
+        isDebug: true,
+      });
+    }
     return await AnnouncementModel.find({
       apps: slug,
       startDate: { $lte: new Date() },
       endDate: { $gte: new Date() },
+      isDebug: false,
     });
   };
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,11 +1,9 @@
-import mongoose, { ConnectOptions } from "mongoose";
+import mongoose from "mongoose";
 
 export const dbConnect = async () => {
   // Determine environment
-  let uri = process.env.LOCAL_URI;
-  if (process.env.NODE_ENV === "development") {
-    uri = process.env.DEV_URI;
-  } else if (process.env.NODE_ENV === "production") {
+  let uri = process.env.DEV_URI;
+  if (process.env.NODE_ENV === "prod") {
     uri = process.env.PROD_URI;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,6 @@ import { authMiddleware } from "./middleware/authMiddleware";
 const app = express();
 app.use(bodyParser.json());
 
-// Define auth middleware first
-app.use(authMiddleware);
-
 // Default Route
 app.get("/", (req, res) => {
   return res.sendFile("index.html", { root: __dirname });
@@ -24,6 +21,10 @@ app.use("/api-docs", swaggerUI.serve, async (req: Request, res: Response) => {
     swaggerUI.generateHTML(await import("../build/swagger.json"))
   );
 });
+
+// Define auth middleware first
+app.use(authMiddleware);
+
 RegisterRoutes(app);
 
 // Define error middleware last

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -8,7 +8,7 @@ export const authMiddleware = async (
   res: Response,
   next: NextFunction
 ): Promise<Response | void> => {
-  // Exclude getActiveAnnouncements route
+  // Exclude getActiveAnnouncements and API docs route
   const routePattern = /^\/announcements\/\w+/;
   if (routePattern.test(req.path)) {
     return next();

--- a/tests/announcements.test.ts
+++ b/tests/announcements.test.ts
@@ -33,21 +33,39 @@ describe("getAnnouncements", () => {
     await AnnouncementModel.deleteMany({});
   });
 
-  it("should return no announcements", async () => {
+  it("should return no announcements no debug", async () => {
+    // given
+    const isDebug = false;
+
     // when
-    const getResponse = await announcementService.getAnnouncements();
+    const getResponse = await announcementService.getAnnouncements(isDebug);
 
     // then
     expect(getResponse).toHaveLength(0);
   });
 
-  it("should return 5 announcements", async () => {
+  it("should return 5 announcements no debug", async () => {
     // given
     const announcements = await AnnouncementFactory.create(5);
+    const isDebug = false;
     await AnnouncementModel.create(announcements);
 
     // when
-    const getResponse = await announcementService.getAnnouncements();
+    const getResponse = await announcementService.getAnnouncements(isDebug);
+
+    // then
+    expect(getResponse).toHaveLength(5);
+  });
+
+  it("should return 5 announcements with debug", async () => {
+    // given
+    const announcements = await AnnouncementFactory.create(5);
+    announcements.forEach((ann) => (ann.isDebug = true));
+    const isDebug = true;
+    await AnnouncementModel.create(announcements);
+
+    // when
+    const getResponse = await announcementService.getAnnouncements(isDebug);
 
     // then
     expect(getResponse).toHaveLength(5);
@@ -73,7 +91,7 @@ describe("insertAnnouncements", () => {
     await AnnouncementModel.deleteMany({});
   });
 
-  it("should have the same fields as the mock", async () => {
+  it("should have the same fields as the mock no debug", async () => {
     // given
     const mocks = await AnnouncementFactory.create(1);
     const mockAnnouncement = mocks[0];
@@ -88,6 +106,29 @@ describe("insertAnnouncements", () => {
     expect(insertResponse.body).toStrictEqual(mockAnnouncement.body);
     expect(insertResponse.endDate).toStrictEqual(mockAnnouncement.endDate);
     expect(insertResponse.imageUrl).toStrictEqual(mockAnnouncement.imageUrl);
+    expect(insertResponse.isDebug).toStrictEqual(mockAnnouncement.isDebug);
+    expect(insertResponse.link).toStrictEqual(mockAnnouncement.link);
+    expect(insertResponse.startDate).toStrictEqual(mockAnnouncement.startDate);
+    expect(insertResponse.title).toStrictEqual(mockAnnouncement.title);
+  });
+
+  it("should have the same fields as the mock with debug", async () => {
+    // given
+    const mocks = await AnnouncementFactory.create(1);
+    const mockAnnouncement = mocks[0];
+    mockAnnouncement.isDebug = true;
+
+    // when
+    const insertResponse = await announcementService.insertAnnouncement(
+      mockAnnouncement
+    );
+
+    // then
+    expect(insertResponse.apps).toStrictEqual(mockAnnouncement.apps);
+    expect(insertResponse.body).toStrictEqual(mockAnnouncement.body);
+    expect(insertResponse.endDate).toStrictEqual(mockAnnouncement.endDate);
+    expect(insertResponse.imageUrl).toStrictEqual(mockAnnouncement.imageUrl);
+    expect(insertResponse.isDebug).toStrictEqual(mockAnnouncement.isDebug);
     expect(insertResponse.link).toStrictEqual(mockAnnouncement.link);
     expect(insertResponse.startDate).toStrictEqual(mockAnnouncement.startDate);
     expect(insertResponse.title).toStrictEqual(mockAnnouncement.title);
@@ -219,6 +260,7 @@ describe("updateAnnouncements", () => {
     expect(updateRequest.body).toStrictEqual(newBody);
     expect(updateRequest.endDate).toStrictEqual(mockAnnouncement.endDate);
     expect(updateRequest.imageUrl).toStrictEqual(mockAnnouncement.imageUrl);
+    expect(updateRequest.isDebug).toStrictEqual(mockAnnouncement.isDebug);
     expect(updateRequest.link).toStrictEqual(mockAnnouncement.link);
     expect(updateRequest.startDate).toStrictEqual(mockAnnouncement.startDate);
     expect(updateRequest.title).toStrictEqual(mockAnnouncement.title);
@@ -232,6 +274,7 @@ describe("updateAnnouncements", () => {
     expect(getRequest[0].body).toStrictEqual(newBody);
     expect(getRequest[0].endDate).toStrictEqual(mockAnnouncement.endDate);
     expect(getRequest[0].imageUrl).toStrictEqual(mockAnnouncement.imageUrl);
+    expect(getRequest[0].isDebug).toStrictEqual(mockAnnouncement.isDebug);
     expect(getRequest[0].link).toStrictEqual(mockAnnouncement.link);
     expect(getRequest[0].startDate).toStrictEqual(mockAnnouncement.startDate);
     expect(getRequest[0].title).toStrictEqual(mockAnnouncement.title);
@@ -260,6 +303,7 @@ describe("updateAnnouncements", () => {
     expect(updateRequest.body).toStrictEqual(newBody);
     expect(updateRequest.endDate).toStrictEqual(mockAnnouncement.endDate);
     expect(updateRequest.imageUrl).toStrictEqual(mockAnnouncement.imageUrl);
+    expect(updateRequest.isDebug).toStrictEqual(mockAnnouncement.isDebug);
     expect(updateRequest.link).toStrictEqual(mockAnnouncement.link);
     expect(updateRequest.startDate).toStrictEqual(mockAnnouncement.startDate);
     expect(updateRequest.title).toStrictEqual(newTitle);
@@ -273,6 +317,7 @@ describe("updateAnnouncements", () => {
     expect(getRequest[0].body).toStrictEqual(newBody);
     expect(getRequest[0].endDate).toStrictEqual(mockAnnouncement.endDate);
     expect(getRequest[0].imageUrl).toStrictEqual(mockAnnouncement.imageUrl);
+    expect(getRequest[0].isDebug).toStrictEqual(mockAnnouncement.isDebug);
     expect(getRequest[0].link).toStrictEqual(mockAnnouncement.link);
     expect(getRequest[0].startDate).toStrictEqual(mockAnnouncement.startDate);
     expect(getRequest[0].title).toStrictEqual(newTitle);
@@ -341,6 +386,7 @@ describe("deleteAnnouncements", () => {
     expect(deleteResponse.body).toStrictEqual(mockAnnouncement.body);
     expect(deleteResponse.endDate).toStrictEqual(mockAnnouncement.endDate);
     expect(deleteResponse.imageUrl).toStrictEqual(mockAnnouncement.imageUrl);
+    expect(deleteResponse.isDebug).toStrictEqual(mockAnnouncement.isDebug);
     expect(deleteResponse.link).toStrictEqual(mockAnnouncement.link);
     expect(deleteResponse.startDate).toStrictEqual(mockAnnouncement.startDate);
     expect(deleteResponse.title).toStrictEqual(mockAnnouncement.title);

--- a/tests/apps.test.ts
+++ b/tests/apps.test.ts
@@ -293,21 +293,25 @@ describe("getActiveAnnouncements", () => {
     await AppModel.deleteMany({});
   });
 
-  it("should return no active announcements with incorrect slug", async () => {
+  it("should return no active announcements with incorrect slug no debug", async () => {
     // given
     const mockApp = (await AppFactory.create(1))[0];
     const mockAnnouncement = (await AnnouncementFactory.create(1))[0];
     await AppModel.create(mockApp);
     await AnnouncementModel.create(mockAnnouncement);
+    const isDebug = false;
 
     // when
-    const response = await appService.getActiveAnnouncements(mockApp.slug);
+    const response = await appService.getActiveAnnouncements(
+      mockApp.slug,
+      isDebug
+    );
 
     // then
     expect(response).toHaveLength(0);
   });
 
-  it("should return no active announcements with correct slug", async () => {
+  it("should return no active announcements with correct slug no debug", async () => {
     // given
     const mockApp = (await AppFactory.create(1))[0];
     const mockAnnouncement = (await AnnouncementFactory.create(1))[0];
@@ -315,15 +319,19 @@ describe("getActiveAnnouncements", () => {
     mockAnnouncement.startDate = mockAnnouncement.endDate;
     await AppModel.create(mockApp);
     await AnnouncementModel.create(mockAnnouncement);
+    const isDebug = false;
 
     // when
-    const response = await appService.getActiveAnnouncements(mockApp.slug);
+    const response = await appService.getActiveAnnouncements(
+      mockApp.slug,
+      isDebug
+    );
 
     // then
     expect(response).toHaveLength(0);
   });
 
-  it("should return one active announcement with correct slug", async () => {
+  it("should return one active announcement with correct slug no debug", async () => {
     // given
     const mockApp = (await AppFactory.create(1))[0];
     const mockAnnouncements = await AnnouncementFactory.create(2);
@@ -343,16 +351,20 @@ describe("getActiveAnnouncements", () => {
     const activeAnnouncement = await AnnouncementModel.create(
       mockAnnouncements[1]
     );
+    const isDebug = false;
 
     // when
-    const response = await appService.getActiveAnnouncements(mockApp.slug);
+    const response = await appService.getActiveAnnouncements(
+      mockApp.slug,
+      isDebug
+    );
 
     // then
     expect(response).toHaveLength(1);
     expect(response[0]._id).toStrictEqual(activeAnnouncement._id);
   });
 
-  it("should return many active announcements with correct slug", async () => {
+  it("should return many active announcements with correct slug no debug", async () => {
     // given
     const mockApp = (await AppFactory.create(1))[0];
     const mockAnnouncements = await AnnouncementFactory.create(2);
@@ -376,9 +388,50 @@ describe("getActiveAnnouncements", () => {
     });
     await AppModel.create(mockApp);
     await AnnouncementModel.create(mockAnnouncements);
+    const isDebug = false;
 
     // when
-    const response = await appService.getActiveAnnouncements(mockApp.slug);
+    const response = await appService.getActiveAnnouncements(
+      mockApp.slug,
+      isDebug
+    );
+
+    // then
+    expect(response).toHaveLength(2);
+  });
+
+  it("should return many active announcements with correct slug with debug", async () => {
+    // given
+    const mockApp = (await AppFactory.create(1))[0];
+    const mockAnnouncements = await AnnouncementFactory.create(2);
+    mockAnnouncements[0].apps.push(mockApp.slug);
+    mockAnnouncements[1].apps.push(mockApp.slug);
+    mockAnnouncements[0].startDate = faker.date.between({
+      from: new Date().getTime() - 1000 * 60 * 60 * 24 * 365 * 1000,
+      to: mockAnnouncements[1].startDate,
+    });
+    mockAnnouncements[0].endDate = faker.date.between({
+      from: mockAnnouncements[1].endDate,
+      to: new Date().getTime() + 1000 * 60 * 60 * 24 * 365 * 1000,
+    });
+    mockAnnouncements[1].startDate = faker.date.between({
+      from: new Date().getTime() - 1000 * 60 * 60 * 24 * 365 * 1000,
+      to: mockAnnouncements[1].startDate,
+    });
+    mockAnnouncements[1].endDate = faker.date.between({
+      from: mockAnnouncements[1].endDate,
+      to: new Date().getTime() + 1000 * 60 * 60 * 24 * 365 * 1000,
+    });
+    mockAnnouncements.forEach((ann) => (ann.isDebug = true));
+    await AppModel.create(mockApp);
+    await AnnouncementModel.create(mockAnnouncements);
+    const isDebug = true;
+
+    // when
+    const response = await appService.getActiveAnnouncements(
+      mockApp.slug,
+      isDebug
+    );
 
     // then
     expect(response).toHaveLength(2);

--- a/tests/mocks/AnnouncementFactory.ts
+++ b/tests/mocks/AnnouncementFactory.ts
@@ -25,6 +25,7 @@ class AnnouncementFactory {
     mockAnnouncement.body = faker.string.alpha({ length: { min: 5, max: 10 } });
     mockAnnouncement.endDate = faker.date.future();
     mockAnnouncement.imageUrl = faker.image.url();
+    mockAnnouncement.isDebug = false;
     mockAnnouncement.link = faker.internet.url();
     mockAnnouncement.startDate = faker.date.between({
       from: new Date(),


### PR DESCRIPTION
## Overview

Add a debug route for getting all announcements and active announcements.

## Changes Made

- Add a query parameter to two routes that returns announcements.
  - The parameter is `debug`. If this value is true, return all announcements with the `isDebug` field as true. False otherwise. 
- Updated environment variables and template.
- Fix auth middleware ordering issue.


## Test Coverage

1. Test with Jest by running `yarn test`.
2. Test with Postman manually.
